### PR TITLE
Disabling nginx proxy buffering

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,3 +20,5 @@ nginx_vhosts:
      }
 nginx_remove_default_vhost: true
 nginx_user: "{{ prosperbot_frontend_user }}"
+nginx_extra_http_options: |
+    proxy_buffering    off;


### PR DESCRIPTION
Adding a configuration option to disable nginx proxy buffering. It apparently
causes some of the API calls to fail when we go over a certain size.